### PR TITLE
Renamed a drawable to avoid confusion

### DIFF
--- a/lib/src/main/res/drawable-hdpi/rounded_rectangle_white.xml
+++ b/lib/src/main/res/drawable-hdpi/rounded_rectangle_white.xml
@@ -3,10 +3,10 @@
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	android:shape="rectangle">
 	<solid
-		android:color="#ffffff" />
+		android:color="#ffffff"/>
 	<stroke
 		android:width="1dp"
-		android:color="#ffffff" />
+		android:color="#ffffff"/>
 	<corners
-		android:radius="5dp"   />
+		android:radius="5dp"/>
 </shape>

--- a/lib/src/main/res/layout/tooltip.xml
+++ b/lib/src/main/res/layout/tooltip.xml
@@ -39,7 +39,7 @@
 				android:layout_height="wrap_content"
 				android:padding="8dp"
 				android:gravity="center"
-				android:background="@drawable/rounded_rectangle"/>
+				android:background="@drawable/rounded_rectangle_white"/>
         </FrameLayout>
 
         <View


### PR DESCRIPTION
Main confusion is that I added a drawable in our WeMesh res folder called rounded_rectangle_black for the Quality selection tooltip.
