### PR TITLE
Catching Null getParent() Race Condition

### DIFF
--- a/lib/src/main/java/com/nhaarman/supertooltips/ToolTipView.java
+++ b/lib/src/main/java/com/nhaarman/supertooltips/ToolTipView.java
@@ -212,6 +212,12 @@ public class ToolTipView extends LinearLayout implements ViewTreeObserver.OnPreD
     }
 
     private void applyToolTipPosition() {
+        if (getParent() == null) {
+            // getParent() should always return the tooltipRelativeLayout that this tooltipView
+            //    is attached to. If it returns null, hosting/parent view was likely destroyed.
+            return;
+        }
+
         final int[] masterViewScreenPosition = new int[2];
         mView.getLocationOnScreen(masterViewScreenPosition);
 


### PR DESCRIPTION
It seems that (assuming our calls using `tooltipRelativeLayout.showToolTipForView()` is done properly) there is a race condition between the onPreDraw() override in `ToolTipView` and our attempts to destroy the hosting activity/fragment. In particular, the view's attempt to measure the position of `((View) getParent())` caused a null pointer exception.
